### PR TITLE
Directory metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 /target/
 /.idea/
 vaadin-jooq.iml
+.vscode
+.devcontainer

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <artifactId>vaadin-jooq</artifactId>
     <version>2.0.2-SNAPSHOT</version>
 
-    <name>Vaadin jOOQ Integration</name>
+    <name>jOOQ for Vaadin</name>
     <description>Integrates Vaadin with jOOQ</description>
     <url>https://github.com/simasch/vaadin-jooq</url>
     <licenses>
@@ -33,6 +33,14 @@
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
         <project.scm.id>github</project.scm.id>
+
+        <!-- Vaadin Add-on properties -->
+        <vaadin.addon.name>${project.name}</vaadin.addon.name>
+        <vaadin.addon.jar>${project.build.finalName}.${project.packaging}</vaadin.addon.jar>
+        <vaadin.addon.version>${project.version}</vaadin.addon.version>
+        <vaadin.addon.owner>Simon Martinelli</vaadin.addon.owner>
+        <vaadin.addon.license>Apache License 2.0</vaadin.addon.license>
+
     </properties>
 
     <dependencies>
@@ -130,6 +138,91 @@
                                 </goals>
                             </execution>
                         </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+       <profile>
+            <id>directory</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-assembly-plugin</artifactId>
+                        <version>3.3.0</version>
+                        <configuration>
+                            <appendAssemblyId>false</appendAssemblyId>
+                            <descriptors>
+                                <descriptor>src/main/assembly/assembly.xml</descriptor>
+                            </descriptors>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>single</goal>
+                                </goals>
+                                <phase>install</phase>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-source-plugin</artifactId>
+                        <version>3.2.1</version>
+                        <executions>
+                            <execution>
+                                <id>attach-sources</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>jar-no-fork</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <version>3.4.1</version>
+                        <executions>
+                            <execution>
+                                <id>attach-javadocs</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>jar</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                        <configuration>
+                            <quiet>true</quiet>
+                            <doclint>none</doclint>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-jar-plugin</artifactId>
+                        <configuration>
+                            <!-- Generated file that shouldn't be included in add-ons -->
+                            <excludes>
+                                <exclude>
+                                    META-INF/VAADIN/config/flow-build-info.json
+                                </exclude>
+                            </excludes>
+                            <archive>
+                                <index>true</index>
+                                <manifest>
+                                    <addClasspath>true</addClasspath>
+                                </manifest>
+                                <manifestEntries>
+                                    <!-- Package format version - do not change these.
+                                         Instead edit the properties in the beginning of pom.xml -->
+                                    <Vaadin-Package-Version>1</Vaadin-Package-Version>
+                                    <Implementation-Title>${vaadin.addon.name}</Implementation-Title>
+                                    <Implementation-Vendor>${vaadin.addon.owner}</Implementation-Vendor>
+                                    <Implementation-Version>${vaadin.addon.version}</Implementation-Version>
+                                    <Vaadin-License-Title>${vaadin.addon.license}</Vaadin-License-Title>
+                                </manifestEntries>
+                            </archive>
+                        </configuration>
                     </plugin>
                 </plugins>
             </build>

--- a/src/main/assembly/MANIFEST.MF
+++ b/src/main/assembly/MANIFEST.MF
@@ -1,0 +1,7 @@
+Manifest-Version: 1.0
+Vaadin-Package-Version: 1
+Vaadin-Addon: ${vaadin.addon.jar}
+Vaadin-License-Title: ${vaadin.addon.license}
+Implementation-Vendor: ${vaadin.addon.owner}
+Implementation-Title: ${vaadin.addon.name}
+Implementation-Version: ${vaadin.addon.version}

--- a/src/main/assembly/assembly.xml
+++ b/src/main/assembly/assembly.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<assembly
+		xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2"
+		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 http://maven.apache.org/xsd/assembly-1.1.2.xsd">
+	<id>addon</id>
+
+	<formats>
+		<format>zip</format>
+	</formats>
+
+	<!-- Do not use because we must put META-INF/MANIFEST.MF there. -->
+	<includeBaseDirectory>false</includeBaseDirectory>
+
+	<fileSets>
+		<fileSet>
+			<directory>..</directory>
+			<includes>
+				<include>LICENSE</include>
+				<include>README.md</include>
+			</includes>
+		</fileSet>
+		<fileSet>
+			<directory>target</directory>
+			<outputDirectory></outputDirectory>
+			<includes>
+				<include>*.jar</include>
+				<include>*.pdf</include>
+			</includes>
+		</fileSet>
+	</fileSets>
+
+	<files>
+		<!-- This is vaadin.com/directory related manifest needed in the
+            zip package -->
+		<file>
+			<source>src/main/assembly/MANIFEST.MF</source>
+			<outputDirectory>META-INF</outputDirectory>
+			<filtered>true</filtered>
+		</file>
+	</files>
+</assembly>


### PR DESCRIPTION
Following metadata updates:
- Rename to match naming Directory requirements (Names cannot start with Vaadin)
- Generate jar manifest entries required for Vaadin Directory publish
- Added Vaadin Add-on Zip assembly for src/javadoc jar files
- Ignored VS Code project files
